### PR TITLE
Version convenience import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 *********
 
+1.0.1 -- 2018-05-02
+===================
+* Add version convenience import to base namespace.
+
 1.0.0 -- 2018-05-02
 ===================
 * Initial public release

--- a/src/dynamodb_encryption_sdk/__init__.py
+++ b/src/dynamodb_encryption_sdk/__init__.py
@@ -18,6 +18,7 @@ from dynamodb_encryption_sdk.encrypted.item import (
 )
 from dynamodb_encryption_sdk.encrypted.resource import EncryptedResource
 from dynamodb_encryption_sdk.encrypted.table import EncryptedTable
+from dynamodb_encryption_sdk.identifiers import __version__
 
 # TableConfiguration
 # MaterialDescription
@@ -26,5 +27,6 @@ from dynamodb_encryption_sdk.encrypted.table import EncryptedTable
 __all__ = (
     'decrypt_dynamodb_item', 'decrypt_python_item',
     'encrypt_dynamodb_item', 'encrypt_python_item',
-    'EncryptedClient', 'EncryptedResource', 'EncryptedTable'
+    'EncryptedClient', 'EncryptedResource', 'EncryptedTable',
+    '__version__'
 )

--- a/src/dynamodb_encryption_sdk/identifiers.py
+++ b/src/dynamodb_encryption_sdk/identifiers.py
@@ -14,7 +14,7 @@
 from enum import Enum
 
 __all__ = ('LOGGER_NAME', 'CryptoAction', 'EncryptionKeyType', 'KeyEncodingType')
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 LOGGER_NAME = 'dynamodb_encryption_sdk'
 USER_AGENT_SUFFIX = 'DynamodbEncryptionSdkPython/{}'.format(__version__)


### PR DESCRIPTION
*Description of changes:*
I noticed this as I was testing the pypi downloads...Python convention is to have the version in `<root namespace>.__version__`. This adds that and bumps us to `v1.0.1`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
