### PR TITLE
Fix MANIFEST.in

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 *********
 
+1.0.2 -- 2018-05-03
+===================
+* Fill out ``MANIFEST.in`` to correctly include necessary files in source build.
+
 1.0.1 -- 2018-05-02
 ===================
 * Add version convenience import to base namespace.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.rst
+include CHANGELOG.rst
+include LICENSE
+include requirements.txt
+
+recursive-include doc *
+recursive-include test *.py

--- a/src/dynamodb_encryption_sdk/identifiers.py
+++ b/src/dynamodb_encryption_sdk/identifiers.py
@@ -14,7 +14,7 @@
 from enum import Enum
 
 __all__ = ('LOGGER_NAME', 'CryptoAction', 'EncryptionKeyType', 'KeyEncodingType')
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 LOGGER_NAME = 'dynamodb_encryption_sdk'
 USER_AGENT_SUFFIX = 'DynamodbEncryptionSdkPython/{}'.format(__version__)


### PR DESCRIPTION
*Description of changes:*

I was certain I had updated this before release, but apparently I missed it. The `MANIFEST.in` determines what is built into the source build, and that needs to include tests and metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
