### PR TITLE
fix AWS KMS integ test to correctly use Binary value rather than bytes for Python 2.7 compatibility

### DIFF
--- a/test/integration/material_providers/test_aws_kms.py
+++ b/test/integration/material_providers/test_aws_kms.py
@@ -14,6 +14,7 @@
 import logging
 import itertools
 
+from boto3.dynamodb.types import Binary
 import hypothesis
 import pytest
 
@@ -43,7 +44,7 @@ def test_verify_user_agent(aws_kms_cmp, caplog):
 
 
 def _many_items():
-    values = ('a string', 1234, b'binary \x00\x88 value')
+    values = ('a string', 1234, Binary(b'binary \x00\x88 value'))
     partition_keys = (('partition_key', value) for value in values)
     sort_keys = (('sort_key', value) for value in values)
     for pairs in itertools.product(partition_keys, sort_keys):


### PR DESCRIPTION
*Description of changes:*

fix AWS KMS integ test to correctly use Binary value rather than bytes for Python 2.7 compatibility

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
