### PR TITLE
fix "network" flag for offline acceptance test vector scenarios that were set incorrectly

### DIFF
--- a/test/vectors/encrypted_item/scenarios.json
+++ b/test/vectors/encrypted_item/scenarios.json
@@ -11,7 +11,7 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/static-aes-hmac-1.json",
-            "network": true
+            "network": false
         },
         {
             "version": "v0",
@@ -22,7 +22,7 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/static-aes-hmac-2.json",
-            "network": true
+            "network": false
         },
         {
             "version": "v1",
@@ -33,7 +33,7 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/static-aes-hmac-3.json",
-            "network": true
+            "network": false
         },
         {
             "version": "v0",
@@ -44,7 +44,7 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/wrapped-rsa-rsa-1.json",
-            "network": true
+            "network": false
         },
         {
             "version": "v1",
@@ -55,7 +55,7 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/wrapped-rsa-rsa-2.json",
-            "network": true
+            "network": false
         },
         {
             "version": "v0",
@@ -66,7 +66,7 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/wrapped-rsa-rsa-3.json",
-            "network": true
+            "network": false
         },
         {
             "version": "v1",
@@ -77,7 +77,7 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/wrapped-aes-hmac-1.json",
-            "network": true
+            "network": false
         },
         {
             "version": "v1",


### PR DESCRIPTION
*Description of changes:*
The "network" flag in acceptance test scenario descriptions is intended to identify whether or not a scenario requires network access. This flag was set incorrectly for most of the scenarios.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
