### PR TITLE
for tox resetdocs, make sure that the directory exists to avoid potential side effects of using rm -f

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -195,9 +195,13 @@ commands =
 # Clear out any generated files from doc/
 [testenv:resetdocs]
 whitelist_externals =
+    mkdir
     rm
 commands =
-    rm -r doc/lib/generated
+    # Make sure that the directory exists to avoid
+    # potential side effects of using rm -f
+    mkdir -p {toxinidir}/doc/lib/generated
+    rm -r {toxinidir}/doc/lib/generated
 
 [testenv:doc8]
 basepython = python3


### PR DESCRIPTION
*Description of changes:*

In the vein of "test more permutations before committing", the thing that the `rm -f` was solving in resetdocs was the case where the generated docs directory did not already exist. I am still of the mind that we should not clobber files in the `rm` step, so this change makes the generated directory if it does not already  exist.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
